### PR TITLE
changelog: remove duplicate 3.0.3 entry

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,11 +8,6 @@
 
 [B]3.0.3[/B]
 
-- Rename unknown-user.png -> DefaultUser.png 
-  part of #8856
-
-[B]3.0.3[/B]
-
 - Removed Player.ShowCodec
 
 [B]3.0.2[/B]


### PR DESCRIPTION
this was supposed to be 3.0.4 entry but now theres already an entry for that which was added later